### PR TITLE
Chore - default node group settings

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,10 +4,6 @@ import * as eks from "@pulumi/eks";
 let name = "k8s-templates-integration-tests";
 const cluster = new eks.Cluster(name, {
     name,
-    minSize: 1,
-    desiredCapacity: 1,
-    maxSize: 1,
-    instanceType: "t4g.nano",
     clusterTags: {
         owner: "RND",
         DO_NOT_DELETE: "DO_NOT_DELETE",


### PR DESCRIPTION
**Problem**
 
After I set custom node group settings it was created but not assigned to the EKS cluster.

**Solution**
Try default settings.